### PR TITLE
Fix README formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,38 +15,31 @@ Open CAFE Core
     === CAFE Core ===
 
 
-The Open Common Automation Framework Engine is the core engine/driver used to build an automated testing framework. It is designed to be used as the
-base engine for building an automated framework for API and non-UI resource testing. It is designed to support functional, integration and
-reliability testing. The engine is **NOT** designed to support performance or load testing.
+The Open Common Automation Framework Engine is the core engine/driver used to build an automated testing framework. It is designed to be used as the base engine for building an automated framework for API and non-UI resource testing. It is designed to support functional, integration and reliability testing. The engine is **NOT** designed to support performance or load testing.
 
-CAFE core provides a model, a pattern and assorted common tools for building automated tests. It provides its own light weight unittest based
-runner, however, it is designed to be modular. It can be extended to support most test case front ends/runners (nose, pytest, lettuce, testr, etc...)
-through driver plug-ins.
+CAFE core provides a model, a pattern and assorted common tools for building automated tests. It provides its own light weight unittest based runner, however, it is designed to be modular. It can be extended to support most test case front ends/runners (nose, pytest, lettuce, testr, etc...) through driver plug-ins.
 
 Supported Operating Systems
 ---------------------------
-Open CAFE Core has been developed primarily in Linux and MAC environments, however, it supports installation and
-execution on Windows
+Open CAFE Core has been developed primarily in Linux and Mac OS X environments; however, it also supports installation and execution on Windows.
 
 Installation
 ------------
 Open CAFE Core can be `installed with pip <https://pypi.python.org/pypi/pip>`_ from the git repository after it is cloned to a local machine.
 
 * Clone this repository to your local machine
-* CD to the root directory in your cloned repository.
-* Run "pip install . --upgrade" and pip will auto install all dependencies.
+* ``cd`` to the root directory in your cloned repository.
+* Run ``pip install . --upgrade`` and pip will auto install all dependencies.
 
-After the CAFE Core is installed you will have command line access to the default unittest runner, the cafe-runner. (See cafe-runner --help for more info)
+After the CAFE Core is installed, you will have command line access to the default unittest runner, the cafe-runner. (See ``cafe-runner --help`` for more info.)
 
-Remember, open CAFE is just the core driver/engine. You have to build an implementation and test repository that use it!
+Remember, Open CAFE is just the core driver/engine. You have to build an implementation and test repository that use it!
 
 Configuration
 --------------
-Open CAFE works out of the box with the cafe-runner (cafe.drivers.unittest). CAFE will auto-generate a base engine.config during installation. This
-base configuration will be installed to: <USER_HOME>/.cloudcafe/configs/engine.config
+Open CAFE works out of the box with the cafe-runner (cafe.drivers.unittest). CAFE will auto-generate a base engine.config during installation. This base configuration will be installed to: ``${HOME}/.cloudcafe/configs/engine.config``
 
-If you wish to modify default installation values you can update the engine.config file after CAFE installation. Keep in mind that the Engine will
-over-write this file on installation/upgrade.
+If you wish to modify default installation values, you can update the engine.config file after CAFE installation. Keep in mind that the Engine will over-write this file on installation/upgrade.
 
 Terminology
 -----------
@@ -56,14 +49,13 @@ Following are some notes on Open CAFE lingo and concepts.
     Although the engine can serve as a basic framework for testing, it's meant to be used as the base for the implementation of a product-specific testing framework.
 
 * Product
-    Anything that's being tested by an implementation of Open CAFE Core. If you would like to see a refernce implementation, there is an `Open Source implementation <https://github.com/stackforge>`_ based on `OpenStack <http://www.openstack.org/>`_.
-
+    Anything that's being tested by an implementation of Open CAFE Core. If you would like to see a reference implementation, there is an `Open Source implementation <https://github.com/stackforge>`_ based on `OpenStack <http://www.openstack.org/>`_.
 
 * Client / Client Method
     A **client** is an "at-least-one"-to-"at-most-one" mapping of a product's functionality to a collection of client methods.  Using a `REST API <https://en.wikipedia.org/wiki/Representational_state_transfer>`_ as an example, a client that represents that API in CAFE will contain at least one (but possibly more) method(s) for every function exposed by that API.  Should a call in the API prove to be too difficult or cumbersome to define via a single **client method**, then multiple client methods can be defined such that as a whole they represent the complete set of that API call's functionality. A **client method** should never be a superset of more than one call's functionality.
 
 * Behavior
-    A **behavior** is a many-to-many mapping of client methods to business logic, functioning as compound methods.  An example behavior might be to POST content, perform a GET to verify the POST, and then return the verified data
+    A **behavior** is a many-to-many mapping of client methods to business logic, functioning as compound methods.  An example behavior might be to POST content, perform a GET to verify the POST, and then return the verified data.
 
 * Model
     A **model** can be many things, but generally is a class that describes a specific data object. An example may be a collection of logic for converting an XML or JSON response into a data object, so that a single consumer can be written to consume the model.

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ execution on Windows
 
 Installation
 ------------
-Open CAFE Core can be [installed with pip](https://pypi.python.org/pypi/pip) from the git repository after it is cloned to a local machine.
+Open CAFE Core can be `installed with pip <https://pypi.python.org/pypi/pip>`_ from the git repository after it is cloned to a local machine.
 
 * Clone this repository to your local machine
 * CD to the root directory in your cloned repository.
@@ -56,11 +56,11 @@ Following are some notes on Open CAFE lingo and concepts.
     Although the engine can serve as a basic framework for testing, it's meant to be used as the base for the implementation of a product-specific testing framework.
 
 * Product
-    Anything that's being tested by an implementation of Open CAFE Core. If you would like to see a refernce implementation, there is an [Open Source implementation](https://github.com/stackforge) based on [OpenStack](http://http://www.openstack.org/)
+    Anything that's being tested by an implementation of Open CAFE Core. If you would like to see a refernce implementation, there is an `Open Source implementation <https://github.com/stackforge>`_ based on `OpenStack <http://www.openstack.org/>`_.
 
 
 * Client / Client Method
-    A **client** is an "at-least-one"-to-"at-most-one" mapping of a product's functionality to a collection of client methods.  Using a [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer) as an example, a client that represents that API in CAFE will contain at least one (but possibly more) method(s) for every function exposed by that API.  Should a call in the API prove to be too difficult or cumbersome to define via a single **client method**, then multiple client methods can be defined such that as a whole they represent the complete set of that API call's functionality. A **client method** should never be a superset of more than one call's functionality.
+    A **client** is an "at-least-one"-to-"at-most-one" mapping of a product's functionality to a collection of client methods.  Using a `REST API <https://en.wikipedia.org/wiki/Representational_state_transfer>`_ as an example, a client that represents that API in CAFE will contain at least one (but possibly more) method(s) for every function exposed by that API.  Should a call in the API prove to be too difficult or cumbersome to define via a single **client method**, then multiple client methods can be defined such that as a whole they represent the complete set of that API call's functionality. A **client method** should never be a superset of more than one call's functionality.
 
 * Behavior
     A **behavior** is a many-to-many mapping of client methods to business logic, functioning as compound methods.  An example behavior might be to POST content, perform a GET to verify the POST, and then return the verified data


### PR DESCRIPTION
The inline syntax before this patch is actually Markdown syntax, which ... well, doesn't really work in RST files. Inline URLs in RST are weirder. This makes the README actually look good in GitHub.